### PR TITLE
Add Class.forName overload methods rewrite

### DIFF
--- a/reflection-rewriter/rewriter/src/main/java/io/papermc/reflectionrewriter/BaseReflectionRules.java
+++ b/reflection-rewriter/rewriter/src/main/java/io/papermc/reflectionrewriter/BaseReflectionRules.java
@@ -58,7 +58,7 @@ public final class BaseReflectionRules {
     }
 
     private static final MethodMatcher CLASS_RULE = MethodMatcher.builder()
-        .match("forName", b -> b.desc("(Ljava/lang/String;)Ljava/lang/Class;", "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;"))
+        .match("forName", b -> b.desc("(Ljava/lang/String;)Ljava/lang/Class;", "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;", "(Ljava/lang/Module;Ljava/lang/String;)Ljava/lang/Class;"))
         .match(Set.of("getField", "getDeclaredField"), b -> b.desc("(Ljava/lang/String;)Ljava/lang/reflect/Field;"))
         .match(Set.of("getMethod", "getDeclaredMethod"), b -> b.desc("(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;"))
         .build();

--- a/reflection-rewriter/rewriter/src/main/java/io/papermc/reflectionrewriter/BaseReflectionRules.java
+++ b/reflection-rewriter/rewriter/src/main/java/io/papermc/reflectionrewriter/BaseReflectionRules.java
@@ -58,7 +58,7 @@ public final class BaseReflectionRules {
     }
 
     private static final MethodMatcher CLASS_RULE = MethodMatcher.builder()
-        .match("forName", b -> b.desc("(Ljava/lang/String;)Ljava/lang/Class;"))
+        .match("forName", b -> b.desc("(Ljava/lang/String;)Ljava/lang/Class;", "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;"))
         .match(Set.of("getField", "getDeclaredField"), b -> b.desc("(Ljava/lang/String;)Ljava/lang/reflect/Field;"))
         .match(Set.of("getMethod", "getDeclaredMethod"), b -> b.desc("(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;"))
         .build();


### PR DESCRIPTION
Currently asm-utils only adds the rewrite rule for `Class.forName(String)`, this pull request adds rewrite rules for `Class.forName(String, boolean, ClassLoader)` and `Class.forName(Module, String)`.

These rewrites are existed in [AbstractDefaultRulesReflectionProxy](https://github.com/PaperMC/asm-utils/blob/main/reflection-rewriter/runtime/src/main/java/io/papermc/reflectionrewriter/runtime/AbstractDefaultRulesReflectionProxy.java) but rules are not added yet.

Tested on Paper 1.21.5 with following code:

```java
Class<?> dataWatcherClazz = Class.forName("net.minecraft.network.syncher.DataWatcher", false, getClassLoader());
logger.info(dataWatcherClazz.getName());
```

- Before this PR: ClassNotFoundException is thrown
- After: Correctly remapped to `net.minecraft.network.syncher.SynchedEntityData` 
